### PR TITLE
Ensure implicitly determined inverse relation is not populated

### DIFF
--- a/lib/mongoid/userstamp.rb
+++ b/lib/mongoid/userstamp.rb
@@ -42,7 +42,7 @@ module Mongoid
       def find_user(user_id)
         begin
           user_id ? Userstamp.config.user_model.unscoped.find(user_id) : nil
-        rescue Mongoid::Errors::DocumentNotFound => e
+        rescue Mongoid::Errors::DocumentNotFound
           nil
         end
       end

--- a/lib/mongoid/userstamp.rb
+++ b/lib/mongoid/userstamp.rb
@@ -3,8 +3,8 @@ module Mongoid
     extend ActiveSupport::Concern
 
     included do
-      belongs_to Userstamp.config.creator_field, class_name: Userstamp.config.user_model_name, autosave: false, optional: true
-      belongs_to Userstamp.config.updater_field, class_name: Userstamp.config.user_model_name, autosave: false, optional: true
+      belongs_to Userstamp.config.creator_field, class_name: Userstamp.config.user_model_name, autosave: false, optional: true, inverse_of: nil
+      belongs_to Userstamp.config.updater_field, class_name: Userstamp.config.user_model_name, autosave: false, optional: true, inverse_of: nil
 
       before_validation :set_updater
       before_validation :set_creator

--- a/spec/mongoid/userstamp_spec.rb
+++ b/spec/mongoid/userstamp_spec.rb
@@ -58,7 +58,7 @@ describe Mongoid::Userstamp do
         subject.creator = user_2
         subject.save!
       end
-      
+
       it 'should not be overridden when saved' do
         expect(subject.creator_id).to eq user_2.id
         expect(subject.creator).to eq user_2
@@ -167,4 +167,9 @@ describe Mongoid::Userstamp do
     end
   end
 
+  it 'does not set inverse relation' do
+    User.current = user_1
+    subject.save!
+    expect(user_1.book).to be_nil
+  end
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -4,4 +4,6 @@ class User
   include Mongoid::Userstamp::User
 
   field :name
+
+  belongs_to :book, optional: true
 end


### PR DESCRIPTION
Found this in our Rails app. See spec changes, but basically we have something like this:
```
class User
  include Mongoid::Document
  include Mongoid::Userstamp::User

  field :name

  belongs_to :user_group, optional: true
end

class UserGroup
  include Mongoid::Document
  include Mongoid::Userstamp::User

  field :name
  has_many :users
end
```

Whenever a new `UserGroup` is created, the current user has it's `user_group` relation set (although not persisted) to this new group.

@paulmach